### PR TITLE
(chore) upgrade carmine version to 2.19.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,6 @@
             :license {:name "Eclipse Public License"
                       :url  "https://github.com/ylgrgyq/carmine-mock-tool"}
             :dependencies [[org.clojure/clojure "1.6.0"]
-                           [com.taoensso/carmine "2.9.0"]]
+                           [com.taoensso/carmine "2.13.0"]]
             :target-path "target/%s"
             :uberjar-name "carmine-mock-tool.jar")
-

--- a/src/carmine_mock_tool/core.clj
+++ b/src/carmine_mock_tool/core.clj
@@ -2,8 +2,7 @@
   (:require [taoensso.carmine.connections :as conn]
             [taoensso.carmine.protocol :as protocol])
   (:import (java.net Socket)
-           (taoensso.carmine.connections NonPooledConnectionPool Connection)
-           (taoensso.carmine.connections NonPooledConnectionPool)))
+           (taoensso.carmine.connections NonPooledConnectionPool Connection)))
 
 (def ^:dynamic *counter* nil)
 

--- a/src/carmine_mock_tool/core.clj
+++ b/src/carmine_mock_tool/core.clj
@@ -48,6 +48,6 @@
   `(binding [*counter* (atom 0)]
      (let [reply# ~reply-gen]
        (with-redefs [conn/pooled-conn fake-pool
-                     protocol/with-replies* (partial fake-replies reply#)]
+                     protocol/-with-replies (partial fake-replies reply#)]
          (mock-funs-new [~@mocked-commands] ~@body)
          (reset! *counter* 0)))))

--- a/test/carmine_mock_tool/core_test.clj
+++ b/test/carmine_mock_tool/core_test.clj
@@ -1,7 +1,13 @@
 (ns carmine-mock-tool.core-test
-  (:require [clojure.test :refer :all]
-            [carmine-mock-tool.core :refer :all]))
+  (:require [taoensso.carmine :as car]
+            [clojure.test :as t]
+            [carmine-mock-tool.core :as sut]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(t/deftest test-mock-carmine-redis-client
+  (let [k ::my-key
+        v ::my-value]
+    (sut/mock-carmine-redis-client
+     (constantly v)
+     [car/get (fn [k*] k*)]
+     (t/is (= k (car/get k)))
+     (t/is (= v (car/wcar (car/get k)))))))


### PR DESCRIPTION
upgrade carmine version to 2.19.1, function name `protocol/-with-replies` was changed in carmine.