### PR TITLE
(chore) rename project and deploy 0.3.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A mocking tool for [com.taoensso/carmine](https://github.com/ptaoussanis/carmine
 
 ## Usage
 
+### Leiningen/Boot
+
+<img src="https://clojars.org/carmine-mock-tool/latest-version.svg">
+
 For instance, here's some code using carmine to save some value for a key into redis.
 ```clojure
 (defmacro wcar* [& body]

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,10 @@
-(defproject org.clojars.ylgrgyq/carmine-mock-tool "0.2.1-SNAPSHOT"
-            :description "FIXME: write description"
-            :url "http://example.com/FIXME"
-            :license {:name "Eclipse Public License"
-                      :url  "https://github.com/ylgrgyq/carmine-mock-tool"}
-            :dependencies [[org.clojure/clojure "1.6.0"]
-                           [com.taoensso/carmine "2.13.0"]]
-            :target-path "target/%s"
-            :uberjar-name "carmine-mock-tool.jar")
+(defproject carmine-mock-tool "0.3.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url  "https://github.com/ylgrgyq/carmine-mock-tool"}
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [com.taoensso/carmine "2.13.0"]]
+  :target-path "target/%s"
+  :uberjar-name "carmine-mock-tool.jar"
+  :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}})


### PR DESCRIPTION
Rename project name to `carmine-mock-tool` and release version `0.3.0-SNAPSHOT` 👀 